### PR TITLE
Fix fatal error when migrating accounts on PHP >= 7.2

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "StripePayments.name",
     "description": "Uses Stripe Elements and the Payment Request API to automatically handle 3D Secure and SCA to send credit cards directly through Stripe.",
     "authors": [

--- a/stripe_payments.php
+++ b/stripe_payments.php
@@ -153,9 +153,8 @@ class StripePayments extends MerchantGateway implements MerchantCc, MerchantCcOf
             $accounts_references = [];
             $accounts_collected = 0;
             $batch_size = Configure::get('StripePayments.migration_batch_size');
-            $account_count = count($legacy_stripe_accounts);
             foreach ($legacy_stripe_accounts as $legacy_stripe_account) {
-                if ($accounts_collected >= min($batch_size, $account_count)) {
+                if ($accounts_collected >= $batch_size) {
                     break;
                 }
 


### PR DESCRIPTION
Removed unnecessary variable
Updated version to v1.0.1

Fixes #15 