### PR TITLE
CORE-5670

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.10.2",
+    "version": "1.10.3",
     "name": "StripePayments.name",
     "description": "StripePayments.description",
     "authors": [

--- a/stripe_payments.php
+++ b/stripe_payments.php
@@ -1080,12 +1080,12 @@ class StripePayments extends MerchantGateway implements MerchantAch, MerchantAch
     }
 
     /**
-     * Convert amount from decimal value to integer representation of cents
+     * Convert amount between decimal value and integer representation of cents
      *
      * @param float $amount
      * @param string $currency
-     * @param string $direction
-     * @return int The amount in cents
+     * @param string $direction 'to' converts dollars to cents, 'from' converts cents to dollars
+     * @return int|float The amount in cents (int) when direction is 'to', or dollars (float) when 'from'
      */
     private function formatAmount($amount, $currency, $direction = 'to')
     {
@@ -1099,7 +1099,8 @@ class StripePayments extends MerchantGateway implements MerchantAch, MerchantAch
                 $amount /= 100;
             }
         }
-        return (int)round($amount);
+
+        return $direction == 'to' ? (int) round($amount) : round($amount, 2);
     }
 
     /**


### PR DESCRIPTION
Fix formatAmount to preserve decimal precision when converting from Stripe

When converting amounts from Stripe (cents to dollars), the method was casting to int which caused rounding errors. A $2.75 payment (275 cents) would become $3.00, causing ACH payments to remain pending due to amount mismatch in webhook validation.