### PR TITLE
Core 5747

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.10.3",
+    "version": "1.10.4",
     "name": "StripePayments.name",
     "description": "StripePayments.description",
     "authors": [

--- a/language/en_us/stripe_payments.php
+++ b/language/en_us/stripe_payments.php
@@ -39,7 +39,7 @@ $lang['StripePayments.tooltip_publishable_key'] = 'Your API Publishable Key is s
 $lang['StripePayments.tooltip_secret_key'] = 'Your API Secret Key is specific to either live or test mode. Be sure you are using the correct key.';
 
 $lang['StripePayments.webhook'] = 'Stripe Webhook';
-$lang['StripePayments.webhook_note'] = 'It is recommended to configure the following url as a Webhook for "payment_intent" events in your Stripe account.';
+$lang['StripePayments.webhook_note'] = 'It is recommended to configure the following url as a Webhook for "payment_intent" and "charge" events in your Stripe account.';
 
 
 $lang['StripePayments.heading_migrate_accounts'] = 'Migrate Old Payment Accounts';

--- a/stripe_payments.php
+++ b/stripe_payments.php
@@ -1675,14 +1675,16 @@ class StripePayments extends MerchantGateway implements MerchantAch, MerchantAch
         if (isset($stripe_status)) {
             switch ($stripe_status) {
                 case 'requires_capture':
+                case 'requires_confirmation':
+                case 'requires_action':
                 case 'requires_payment_method':
                     $status = 'pending';
                     break;
+                case 'processing':
                 case 'pending':
-                    // ACH charges start as 'pending' while clearing through the bank.
-                    // Optimistically approve to match processStoredAch() behavior and
-                    // prevent the webhook from downgrading an already-approved transaction.
-                    // If the transfer fails, charge.failed will update to declined.
+                    // ACH payments clearing through the bank (PaymentIntent 'processing' or Charge 'pending').
+                    // Optimistically approve to match processStoredAch() behavior and prevent
+                    // re-charging. If the transfer fails, webhooks will update to declined.
                     $status = 'approved';
                     break;
                 case 'canceled':


### PR DESCRIPTION
After migrating ACH processing from the Stripe Charges API to the PaymentIntents API, the webhook handler still only accepted charge events, so when Stripe sent payment_intent.succeeded to confirm an ACH payment, it was silently rejected, leaving transactions stuck in "pending". Even if it had accepted the event, the code extracted data.object.id (which is pi_xxx for payment intents) instead of data.object.latest_charge (ch_xxx), so the database lookup would have failed anyway. The fix accepts both event types, extracts the correct charge ID for each, and adds a safety check allowing the asynchronous ACH confirmation to flow through and close the invoice.

Assume ACH to be "approved" initially rather than waiting for it to clear after 3-5 days so that the invoice will be closed and payment not re-attempted. Bump version.