### PR TITLE
Fix race condition where charge.refunded webhook overwrites refund st…

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.10.4",
+    "version": "1.10.5",
     "name": "StripePayments.name",
     "description": "StripePayments.description",
     "authors": [

--- a/stripe_payments.php
+++ b/stripe_payments.php
@@ -1672,7 +1672,11 @@ class StripePayments extends MerchantGateway implements MerchantAch, MerchantAch
         // Get event status
         $status = 'error';
         $stripe_status = $latest_charge->status ?? $payload->data->object->status ?? 'failed';
-        if (isset($stripe_status)) {
+
+        // Check if charge was refunded before mapping status
+        if ($latest_charge->refunded ?? $payload->data->object->refunded ?? false) {
+            $status = 'refunded';
+        } elseif (isset($stripe_status)) {
             switch ($stripe_status) {
                 case 'requires_capture':
                 case 'requires_confirmation':


### PR DESCRIPTION
…atus

Check the charge's refunded boolean property before mapping status to prevent the webhook from overwriting a transaction back to 'approved' after it has been properly set to 'refunded'. Stripe charges maintain status='succeeded' even after being refunded, so we must check the refunded property explicitly.

CORE-5784