### PR TITLE
Route ACH verification through verifyAch() and mirror Stripe's status

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.2",
+    "version": "2.0.3",
     "name": "StripePayments.name",
     "description": "StripePayments.description",
     "authors": [

--- a/language/en_us/stripe_payments.php
+++ b/language/en_us/stripe_payments.php
@@ -6,6 +6,8 @@ $lang['StripePayments.!error.secret_key.empty'] = 'Please enter a Secret Key.';
 $lang['StripePayments.!error.secret_key.valid'] = 'Unable to connect to the Stripe API using the given Secret Key.';
 
 $lang['StripePayments.!error.bank_account_unverified'] = 'You need to verify your bank account before you can use it to make a payment.';
+$lang['StripePayments.!error.ach.invalid_account'] = 'The bank account could not be found for this customer.';
+$lang['StripePayments.!error.ach.unverified'] = 'The bank account could not be verified. Please confirm the deposit amounts and try again.';
 $lang['StripePayments.!error.invalid_request_error'] = 'The payment gateway returned an error when processing the request.';
 $lang['StripePayments.!error.india_mandate_max_amount.format'] = 'Please enter a valid amount for the maximum recurring charge.';
 
@@ -20,9 +22,7 @@ $lang['StripePayments.ach_form.field_holder_type_company'] = 'Company';
 $lang['StripePayments.ach_form.field_account_number'] = 'Account Number';
 $lang['StripePayments.ach_form.field_routing_number'] = 'Routing Number';
 
-$lang['StripePayments.ach_form.verification_notice'] = 'We sent two small deposits to this bank account. To verify this account, please confirm the amounts of these deposits.';
-$lang['StripePayments.ach_form.field_first_deposit'] = 'First Deposit';
-$lang['StripePayments.ach_form.field_second_deposit'] = 'Second Deposit';
+$lang['StripePayments.ach_form.verification_notice'] = 'The bank account currently on file has not been verified. Entering new bank account details below will replace it.';
 
 $lang['StripePayments.ach_form.mandate_authorization'] = 'By submitting this form, you authorize %1$s to debit the bank account specified above for any amount owed for charges arising from your use of %1$s services and/or purchase of products from %1$s, pursuant to %1$s website and terms, until this authorization is revoked. You may amend or cancel this authorization at any time by providing notice to %1$s with 30 (thirty) days notice.';
 $lang['StripePayments.ach_form.mandate_future_usage'] = 'If you use %1$s services or purchase additional products periodically pursuant to %1$s terms, you authorize %1$s to debit your bank account periodically. Payments that fall outside of the regular debits authorized above will only be debited after your authorization is obtained.';

--- a/stripe_payments.php
+++ b/stripe_payments.php
@@ -11,7 +11,7 @@
  * @license http://www.blesta.com/license/ The Blesta License Agreement
  * @link http://www.blesta.com/ Blesta
  */
-class StripePayments extends MerchantGateway implements MerchantAch, MerchantAchOffsite, MerchantAchVerification, MerchantAchForm, MerchantCc, MerchantCcOffsite, MerchantCcForm
+class StripePayments extends MerchantGateway implements MerchantAch, MerchantAchOffsite, MerchantAchVerification, MerchantAchStatus, MerchantAchForm, MerchantCc, MerchantCcOffsite, MerchantCcForm
 {
     /**
      * @var array An array of meta data for this gateway
@@ -1417,6 +1417,32 @@ class StripePayments extends MerchantGateway implements MerchantAch, MerchantAch
     public function requiresAchStorage()
     {
         return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAchAccountStatus($client_reference_id, $account_reference_id)
+    {
+        if (empty($client_reference_id) || empty($account_reference_id)) {
+            return null;
+        }
+
+        $account = $this->handleApiRequest(
+            ['Stripe\Customer', 'retrieveSource'],
+            [$client_reference_id, $account_reference_id],
+            $this->base_url . 'customers - retrieveSource'
+        );
+
+        // The status cannot be determined when the bank account could not be fetched. Discard the
+        // error so the caller keeps the status it already has rather than treating this as a failure
+        if ($this->Input->errors()) {
+            $this->Input->setErrors([]);
+
+            return null;
+        }
+
+        return $this->getAchStatus($account);
     }
 
     /**

--- a/stripe_payments.php
+++ b/stripe_payments.php
@@ -1368,8 +1368,8 @@ class StripePayments extends MerchantGateway implements MerchantAch, MerchantAch
             $this->base_url . 'setup_intents - create'
         );
 
-        // Get bank account, if already exists
-        $status = 'new';
+        // Determine whether the stored bank account, if any, has been verified with Stripe
+        $verified = true;
         if (!empty($account_info['reference_id']) && !empty($account_info['client_reference_id'])) {
             $account = $this->handleApiRequest(
                 ['Stripe\Customer', 'retrieveSource'],
@@ -1377,9 +1377,13 @@ class StripePayments extends MerchantGateway implements MerchantAch, MerchantAch
                 $this->base_url . 'customers - retrieveSource'
             );
 
-            if ($account->status == 'new') {
-                $status = 'unverified';
+            // Being unable to fetch the account is not fatal here, this form only collects new bank
+            // account details, so discard the error and treat the account as unverified
+            if ($this->Input->errors()) {
+                $this->Input->setErrors([]);
             }
+
+            $verified = $this->achVerified($account);
         }
 
         // Check if Stripe.js is already loaded
@@ -1399,7 +1403,7 @@ class StripePayments extends MerchantGateway implements MerchantAch, MerchantAch
         $this->view->set('setup_intent', $setup_intent);
         $this->view->set('meta', $this->meta);
         $this->view->set('types', $this->Accounts->getAchTypes());
-        $this->view->set('status', $status);
+        $this->view->set('verified', $verified);
         $this->view->set('holder_types', $holder_types);
         $this->view->set('account_info', $account_info);
         $this->view->set('company', $this->Companies->get(Configure::get('Blesta.company_id')));
@@ -1413,6 +1417,31 @@ class StripePayments extends MerchantGateway implements MerchantAch, MerchantAch
     public function requiresAchStorage()
     {
         return true;
+    }
+
+    /**
+     * Determines whether the given Stripe bank account has completed micro-deposit verification.
+     * Stripe only considers a bank account usable for debits once its status is "verified", every
+     * other status ("new", "validated", "verification_failed", "errored") still requires verification
+     *
+     * @param mixed $account The Stripe bank account object, or the error response from a failed request
+     * @return bool True if the bank account has been verified with Stripe, false otherwise
+     */
+    private function achVerified($account)
+    {
+        return ($account->status ?? null) === Stripe\BankAccount::STATUS_VERIFIED;
+    }
+
+    /**
+     * Maps the verification status of the given Stripe bank account to the payment account status
+     * used by Blesta, so the locally stored status always mirrors Stripe
+     *
+     * @param mixed $account The Stripe bank account object, or the error response from a failed request
+     * @return string The payment account status, either "active" or "unverified"
+     */
+    private function getAchStatus($account)
+    {
+        return $this->achVerified($account) ? 'active' : 'unverified';
     }
 
     /**
@@ -1517,7 +1546,8 @@ class StripePayments extends MerchantGateway implements MerchantAch, MerchantAch
         return [
             'client_reference_id' => ($customer->id ?? $client_reference_id),
             'reference_id' => ($account_info['reference_id'] ?? null),
-            'last4' => ($account->last4 ?? null)
+            'last4' => ($account->last4 ?? null),
+            'status' => $this->getAchStatus($account)
         ];
     }
 
@@ -1526,6 +1556,34 @@ class StripePayments extends MerchantGateway implements MerchantAch, MerchantAch
      */
     public function updateAch(array $account_info, array $contact, $client_reference_id, $account_reference_id)
     {
+        // The reference ID given must be a single-use token created for a new bank account. When it is
+        // missing, or is still the ID of the bank account already stored off site, there are no new bank
+        // details to store, so leave the existing bank account attached to the customer untouched
+        $reference_id = ($account_info['reference_id'] ?? null);
+        if (empty($reference_id) || $reference_id == $account_reference_id) {
+            $account = $this->handleApiRequest(
+                ['Stripe\Customer', 'retrieveSource'],
+                [$client_reference_id, $account_reference_id],
+                $this->base_url . 'customers - retrieveSource'
+            );
+
+            if ($this->Input->errors()) {
+                return false;
+            }
+
+            $account_data = [
+                'client_reference_id' => $client_reference_id,
+                'reference_id' => $account_reference_id,
+                'status' => $this->getAchStatus($account)
+            ];
+
+            if (!empty($account->last4)) {
+                $account_data['last4'] = $account->last4;
+            }
+
+            return $account_data;
+        }
+
         // Add a new bank account to the same client
         $account_data = $this->storeAch($account_info, $contact, $client_reference_id);
 
@@ -1558,22 +1616,44 @@ class StripePayments extends MerchantGateway implements MerchantAch, MerchantAch
             return false;
         }
 
-        // Verify bank account
-        if (isset($account->customer) && $account->customer == $client_reference_id) {
+        // The deposit amounts can only be submitted for a bank account belonging to this customer.
+        // Never report success without confirming the ownership of the account
+        if (($account->customer ?? null) != $client_reference_id) {
+            $this->Input->setErrors([
+                'verify' => ['invalid' => Language::_('StripePayments.!error.ach.invalid_account', true)]
+            ]);
+
+            return false;
+        }
+
+        // Verify bank account, an account already verified with Stripe requires no further action
+        if (!$this->achVerified($account)) {
             try {
-                $account->verify(['amounts' => [($vars['first_deposit'] ?? 0), ($vars['second_deposit'] ?? 0)]]);
+                // Stripe expects the deposit amounts in cents and refreshes the account in place
+                $account->verify(
+                    ['amounts' => [(int) ($vars['first_deposit'] ?? 0), (int) ($vars['second_deposit'] ?? 0)]]
+                );
             } catch (Throwable $e) {
                 $this->Input->setErrors(['verify' => ['error' => $e->getMessage()]]);
+
+                return false;
             }
         }
 
-        if ($this->Input->errors()) {
+        // Only report success when Stripe considers the bank account verified, otherwise the account
+        // would be marked active locally while it remains unusable for debits
+        if (!$this->achVerified($account)) {
+            $this->Input->setErrors([
+                'verify' => ['unverified' => Language::_('StripePayments.!error.ach.unverified', true)]
+            ]);
+
             return false;
         }
 
         return [
             'client_reference_id' => $client_reference_id,
-            'reference_id' => $account_reference_id
+            'reference_id' => $account_reference_id,
+            'status' => 'active'
         ];
     }
 

--- a/views/default/ach_form.pdt
+++ b/views/default/ach_form.pdt
@@ -1,25 +1,11 @@
 <div id="stripe-ach-form">
     <div id="ach-element">
         <?php
-        if (($status ?? 'new') == 'unverified') {
+        if (!($verified ?? true)) {
         ?>
         <p><?php $this->_('StripePayments.ach_form.verification_notice'); ?></p>
-        <div class="form-group">
-            <?php
-            $this->Form->label($this->_('StripePayments.ach_form.field_first_deposit', true), 'first_deposit');
-            $this->Form->fieldText('first_deposit', null, ['id' => 'first_deposit', 'maxlength' => '2', 'placeholder' => '$0.']);
-            ?>
-        </div>
-        <div class="form-group">
-            <?php
-            $this->Form->label($this->_('StripePayments.ach_form.field_second_deposit', true), 'second_deposit');
-            $this->Form->fieldText('second_deposit', null, ['id' => 'second_deposit', 'maxlength' => '2', 'placeholder' => '$0.']);
-            ?>
-        </div>
         <?php
         }
-
-        if (($status ?? 'new') == 'new') {
         ?>
         <div class="form-group">
             <?php
@@ -45,9 +31,6 @@
             $this->Form->fieldText('routing_number', null, ['id' => 'routing_number', 'maxlength' => '9', 'placeholder' => $this->_('StripePayments.ach_form.field_routing', true)]);
             ?>
         </div>
-        <?php
-        }
-        ?>
 
         <p class="mb-0 mt-2"><small><?php $this->_('StripePayments.ach_form.mandate_authorization', false, ($company->name ?? ''));?></small></p>
         <p id="future_usage_mandate" class="mt-0 mt-2"><small><?php $this->_('StripePayments.ach_form.mandate_future_usage', false, ($company->name ?? ''));?></small></p>
@@ -56,16 +39,10 @@
     <!-- Used to display form errors. -->
     <div id="ach-errors" role="alert"></div>
     <?php
-    if (($status ?? 'new') == 'new') {
-        $this->Form->fieldHidden('type', '', ['id' => 'type']);
-        $this->Form->fieldHidden('reference_id', '', ['id' => 'reference_id']);
-    } elseif (($status ?? 'new') == 'unverified') {
-        $this->Form->fieldHidden('type', $account_info['type'] ?? null, ['id' => 'type']);
-        $this->Form->fieldHidden('reference_id', $account_info['reference_id'] ?? null, ['id' => 'reference_id']);
-        $this->Form->fieldHidden('client_reference_id', $account_info['client_reference_id'] ?? null, ['id' => 'client_reference_id']);
-    }
-
-    if (($status ?? 'new') == 'new') {
+    // The reference ID is always populated with a single-use token created from the fields above,
+    // it is never the ID of a bank account already stored off site
+    $this->Form->fieldHidden('type', '', ['id' => 'type']);
+    $this->Form->fieldHidden('reference_id', '', ['id' => 'reference_id']);
     ?>
     <?php if ($load_stripe ?? false) { ?><script src="https://js.stripe.com/v3/"></script><?php } ?>
     <script>
@@ -237,7 +214,4 @@
             }
         })();
     </script>
-    <?php
-    }
-    ?>
 </div>


### PR DESCRIPTION
The ACH form rendered the micro-deposit fields on the edit page whenever Stripe reported the bank account as new, along with a hidden reference_id holding the existing ba_ source. Submitting them went through updateAch(), which attempted to attach that source as a single-use token and failed with "No such token". The deposit fields are gone from this form, so verification only happens on the verification page, which posts to verifyAch().

- Only Stripe's "verified" status maps to an active account. Previously any status other than "new" (validated, verification_failed, errored) was read as verified
- verifyAch() errors instead of silently reporting success when the bank account cannot be confirmed to belong to the customer, and re-checks the refreshed status before returning, so an account is never marked active while Stripe still considers it unverified
- updateAch() leaves the stored bank account untouched when no new token was given, rather than re-attaching an ID Stripe cannot accept
- storeAch(), updateAch() and verifyAch() report the account status back to Blesta